### PR TITLE
Readme.md Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 ## How to contribute?
 
 1. Fork this repository into your github account
-2. Clone this project into your local machine.<br/> `git clone https://github.com/Developer-Students-Clubs-MESCOE/To-do-list-in-React.git`
+2. Clone this project into your local machine.<br/> `git clone https://github.com/Developer-Students-Clubs-MESCOE/HacktoberFest-JS-Calculator.git`
 3. make a new branch.<br/> `git checkout -b branch-name`
 4. push your code into this branch.<br/>
    `git add .`<br/>


### PR DESCRIPTION
The previous readme.md had the "git clone" link of a different repository.